### PR TITLE
allow use of msg ids with utf8 chars

### DIFF
--- a/lib/Locale/Simple.pm
+++ b/lib/Locale/Simple.pm
@@ -101,6 +101,8 @@ sub ldnp {
 		}
 		$return = sprintf($idp && $n != 1 ? $idp : $id, @args);
 	} else {
+		# L::TD handles msg ids as bytes internally
+		utf8::encode($id);
 		my $gt = dnpgettext($td, $ctxt, $id, $idp, $n);
 		# Fixing bad utf8 handling
 		utf8::decode($gt);


### PR DESCRIPTION
The msgids from the mo file are read in as bytes in L::TD, as such they need
to be encoded before being sent to it, otherwise they wouldn't match any keys
and translations would not be found for them.
