### PR TITLE
allow output of scraper to be recognized by poedit

### DIFF
--- a/bin/locale_simple_scraper
+++ b/bin/locale_simple_scraper
@@ -193,6 +193,7 @@ if ($output eq 'po') {
 		for (qw( msgctxt msgid msgid_plural )) {
 			print $_.' "'.Locale::Simple::gettext_escape($token{$k}{$_}).'"'."\n" if defined $token{$k}{$_};
 		}
+		print q[msgstr ""\n];
 	}
 } elsif ($output eq 'perl') {
 	print Dumper \@found;


### PR DESCRIPTION
Without an empty msgstr line, poedit will not recognize msgid lines as items
to be translated, so adding it results in useful .po files.
