### PR TITLE
Fix PO header parsing

### DIFF
--- a/bin/po2json
+++ b/bin/po2json
@@ -81,10 +81,10 @@ sub main
             my $qmsgstr = $po->msgstr;
             my $cur = $po->dequote( $qmsgstr );
             my %cur;
-            foreach my $h (split(/\\n/, $cur))
+            foreach my $h (split(/\n/s, $cur))
             {
                 next unless length($h);
-                my @h = split(':', $h, 2);
+                my @h = split(': ', $h, 2);
 
                 if (length($cur{$h[0]})) {
                     warn "SKIPPING DUPLICATE HEADER LINE: $h\n";


### PR DESCRIPTION
On a Debian 8 Jessie system I had problems with the header parsing of
po2json leading to more or less garbage in the result:

```
NO PLURAL FORM HEADER FOUND - DEFAULTING TO 2
{
  "": {
    "Project-Id-Version": " iswebgui\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2017-02-22 13:33+0100\nPO-Revision-Date: 2017-02-22 17:11+0100\nLast-Translator: Alexander Dahl <post@lespocky.de>\nLanguage-Team: \nLanguage: de\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=(n != 1);\nX-Generator: Poedit 1.6.10\nX-Poedit-SourceCharset: UTF-8\n"
  },
  "Channel": [
    null,
    "Kanal"
  ]
}
```

Debugging showed the split of the header msgstr in separate lines did
not work, resulting in only one big line as you can see above. Fixing
the arguments of 'split()' solved the problem. While at it I "fixed" the
separator for the key/value split of the line itself to get rid of a
leading space. This could certainly be done more elegant, but works for
me. Result now looks as expected, without error messages:

```
{
  "Channel": [
    null,
    "Kanal"
  ],
  "": {
    "Content-Type": "text/plain; charset=UTF-8",
    "Plural-Forms": "nplurals=2; plural=(n != 1);",
    "POT-Creation-Date": "2017-02-22 13:33+0100",
    "Report-Msgid-Bugs-To": "",
    "Project-Id-Version": "iswebgui",
    "Language": "de",
    "X-Poedit-SourceCharset": "UTF-8",
    "X-Generator": "Poedit 1.6.10",
    "Language-Team": "",
    "Last-Translator": "Alexander Dahl <post@lespocky.de>",
    "Content-Transfer-Encoding": "8bit",
    "PO-Revision-Date": "2017-02-22 17:11+0100",
    "MIME-Version": "1.0"
  }
}
```